### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,11 +24,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    redirect_to root_path unless @item.user_id == current_user.id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -43,7 +41,7 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to root_path if current_user.id == @item.user_id && @item.purchase_history.present?
+    redirect_to root_path if current_user.id != @item.user_id || @item.purchase_history.present?
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     @items = Item.order('created_at DESC')
@@ -19,10 +21,32 @@ class ItemsController < ApplicationController
   end
 
   def show
+  end
+
+  def edit
+    unless @item.user_id == current_user.id
+      redirect_to root_path
+    end
+  end
+
+  def update
     @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render action: :edit
+    end
   end
 
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    redirect_to root_path if current_user.id == @item.user_id && @item.purchase_history.present?
+  end
 
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :price, :delivery_fee_id, :delivery_area_id,

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,9 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless @item.user_id == current_user.id
-      redirect_to root_path
-    end
+    redirect_to root_path unless @item.user_id == current_user.id
   end
 
   def update

--- a/app/controllers/purchase_histories_controller.rb
+++ b/app/controllers/purchase_histories_controller.rb
@@ -19,7 +19,7 @@ class PurchaseHistoriesController < ApplicationController
   end
 
   private
-  
+
   def set_item
     @item = Item.find(params[:item_id])
   end
@@ -29,11 +29,13 @@ class PurchaseHistoriesController < ApplicationController
   end
 
   def purchase_params
-    params.require(:purchase_address).permit(:postal_code, :prefecture_id, :city, :address, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+    params.require(:purchase_address).permit(:postal_code, :prefecture_id, :city, :address, :building, :phone_number).merge(
+      user_id: current_user.id, item_id: params[:item_id], token: params[:token]
+    )
   end
 
   def pay_item
-    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     Payjp::Charge.create(
       amount: @item.price,
       card: purchase_params[:token],

--- a/app/models/purchase_address.rb
+++ b/app/models/purchase_address.rb
@@ -21,6 +21,7 @@ class PurchaseAddress
 
   def save
     purchase_history = PurchaseHistory.create(user_id: user_id, item_id: item_id)
-    DeliveryAddress.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, address: address, building: building, phone_number: phone_number, purchase_history_id: purchase_history.id)
+    DeliveryAddress.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, address: address,
+                           building: building, phone_number: phone_number, purchase_history_id: purchase_history.id)
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,157 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with model: @item, local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
+    <%# 商品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        商品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :image, id:"item-image" %>
+      </div>
+    </div>
+    <%# /商品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:delivery_area_id, DeliveryArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:delivery_date_id, DeliveryDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/spec/factories/purchase_addresses.rb
+++ b/spec/factories/purchase_addresses.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     city { '東京都' }
     address { '1-1 サンプル' }
     building { '東京ハイツ' }
-    phone_number { "00012345678" }
-    token { "tok_abcdefghijk00000000000000000" }
+    phone_number { '00012345678' }
+    token { 'tok_abcdefghijk00000000000000000' }
   end
 end

--- a/spec/models/purchase_address_spec.rb
+++ b/spec/models/purchase_address_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe PurchaseAddress, type: :model do
-  before do 
+  before do
     user = FactoryBot.create(:user)
     item = FactoryBot.create(:item)
-    @purchase_address = FactoryBot.build(:purchase_address, user_id: user.id, item_id: item.id )
+    @purchase_address = FactoryBot.build(:purchase_address, user_id: user.id, item_id: item.id)
     sleep 0.1
   end
 
@@ -27,12 +27,12 @@ RSpec.describe PurchaseAddress, type: :model do
     it 'postal_codeが半角のハイフンを含んだ正しい形式でないと保存できないこと' do
       @purchase_address.postal_code = '1234567'
       @purchase_address.valid?
-      expect(@purchase_address.errors.full_messages).to include("Postal code is invalid")
+      expect(@purchase_address.errors.full_messages).to include('Postal code is invalid')
     end
     it 'prefecture_idを選択していないと保存できないこと' do
       @purchase_address.prefecture_id = 1
       @purchase_address.valid?
-      expect(@purchase_address.errors.full_messages).to include("Prefecture must be other than 1")
+      expect(@purchase_address.errors.full_messages).to include('Prefecture must be other than 1')
     end
     it 'prefecture_idが空だと保存できないこと' do
       @purchase_address.prefecture_id = ''
@@ -57,17 +57,17 @@ RSpec.describe PurchaseAddress, type: :model do
     it 'phone_numberが12桁以上の数値だと保存できないこと' do
       @purchase_address.phone_number = '000123456789'
       @purchase_address.valid?
-      expect(@purchase_address.errors.full_messages).to include("Phone number is too long (maximum is 11 characters)")
+      expect(@purchase_address.errors.full_messages).to include('Phone number is too long (maximum is 11 characters)')
     end
     it 'phone_numberが英数混合では保存できないこと' do
       @purchase_address.phone_number = '000-1234-abcd'
       @purchase_address.valid?
-      expect(@purchase_address.errors.full_messages).to include("Phone number is too long (maximum is 11 characters)")
+      expect(@purchase_address.errors.full_messages).to include('Phone number is too long (maximum is 11 characters)')
     end
     it 'phone_numberが半角英語だけでは保存できないこと' do
       @purchase_address.phone_number = 'abcdefghijk'
       @purchase_address.valid?
-      expect(@purchase_address.errors.full_messages).to include("Phone number is invalid")
+      expect(@purchase_address.errors.full_messages).to include('Phone number is invalid')
     end
     it 'tokenが空だと保存できないこと' do
       @purchase_address.token = nil


### PR DESCRIPTION
# What
商品情報編集機能の実装

# Why
一度出品した商品を編集できるようにするため

# Gyazo
- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/81799874248f8b85f48b063283d9e73c
- 正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/8d8c722a2a1b4ff25afb0e146329d402
- 入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/4e09565bf450c6ce23e314c8722052e9
- 何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/089d91477f5ce0265e000ab6fa3e2cf8
- ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/eec993bba295142765457bf1c892448b
- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/bbadfc50e22e50e95bc731ff726a243b
- ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
https://gyazo.com/4abe0d75bd09e4a5410b6c6c063ea174
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/160bf7ed7cfb281861580a1aeb6b7ac9